### PR TITLE
Mastodon integration

### DIFF
--- a/integrations/index.ts
+++ b/integrations/index.ts
@@ -3,7 +3,12 @@ import { Integration, BDS } from "./integration.ts";
 import Discord from "./discord/index.ts";
 
 const Integrations: Integration[] = [];
-Integrations.push(new Discord);
+if (process.env.DISCORD_INTEGRATION !== undefined) {
+    Integrations.push(new Discord);
+}
+if (process.env.MASTO_INTEGRATION !== undefined) {
+    Integrations.push(new Mastodon);
+}
 
 
 // Event emitter stuff
@@ -27,6 +32,7 @@ export function emitBDS(bds: BDS) {
 };
 
 import { Platform } from "../src/platforms/common.ts"
+import Mastodon from "./mastodon/index.ts";
 export function emitPlatformRelease(platform: Platform) {
     for (let i = 0; i < Integrations.length; i++) {
         const integration = Integrations[i];

--- a/integrations/mastodon/functionality.ts
+++ b/integrations/mastodon/functionality.ts
@@ -1,0 +1,98 @@
+import { mastodon } from "masto";
+import { ArticleData } from "../../src/changelog.ts";
+import { Platform } from "../../src/platforms/common.ts";
+import { BDS } from "../integration.ts";
+import Mastodon from "./index.ts";
+
+async function postChangelog(
+    masto: Mastodon,
+    isPreview: boolean, isHotfix: boolean,
+    data: ArticleData
+) {
+    const emoji = isPreview ? "🍌" : (isHotfix ? "🌶" : "🍏");
+    const type = isPreview ? "Preview" : (isHotfix ? "Hotfix" : "Stable release");
+    const status = `${emoji} New Minecraft Bedrock Edition ${type}: **${data.version}**\n\n${data.article.url}`
+
+    const mediaIds: string[] = []
+    if (typeof data.thumbnail === 'string') {
+        const image = await fetch(data.thumbnail)
+        mediaIds.push((await masto.client.v2.media.create({
+            file: await image.blob(),
+            description: ""
+        })).id)
+    }
+
+    return masto.client.v1.statuses.create({
+        visibility: "public",
+        status,
+        mediaIds
+    })
+}
+
+async function bdsRelease(masto: Mastodon, status: mastodon.v1.Status, bds: BDS) {
+    const statusText = "Bedrock Dedicated Server for "
+            + `**${bds.isPreview ? "Minecraft Preview" : "Minecraft Bedrock"} v${bds.version}**`
+            + " is out now!"
+    
+    await masto.client.v1.statuses.create({
+        inReplyToId: status.id,
+        status: statusText
+    })
+}
+
+async function platformRelease(masto: Mastodon, status: mastodon.v1.Status, platform: Platform) {
+    const statusText = `**${platform.fetchPreview ? "Minecraft Preview" : "Minecraft Bedrock"} v${platform.latestVersion}**`
+            + ` is out now on the ${platform.name}!`
+    
+    await masto.client.v1.statuses.create({
+        inReplyToId: status.id,
+        status: statusText
+    })
+}
+
+export async function newChangelog(
+    masto: Mastodon,
+    isPreview: boolean, isHotfix: boolean,
+    data: ArticleData
+) {
+    const status = postChangelog(masto, isPreview, isHotfix, data)
+
+    // Platform Release
+        const platformListener = async (platform: Platform) => {
+            const post = await status;
+            if (post == void 0) {
+                masto.off("platformRelease", platformListener);
+                return;
+            };
+    
+            if (isPreview !== platform.fetchPreview
+                || data.version !== platform.latestVersion)
+                return;
+    
+            platformRelease(masto, post, platform);
+            masto.off("platformRelease", platformListener);
+        };
+        masto.on("platformRelease", platformListener);
+                        
+        // BDS Release
+        const bdsListener = async (bds: BDS) => {
+            const post = await status;
+            if (post == void 0) {
+                masto.off("platformRelease", platformListener);
+                return;
+            };
+    
+            if (isPreview !== bds.isPreview
+                || data.version !== bds.version)
+                return;
+    
+            bdsRelease(masto, post, bds);
+            masto.off("BDS", bdsListener);
+        };
+        masto.on("BDS", bdsListener);
+    
+    const post = await status;
+    if (post) {
+        return post;
+    }
+}

--- a/integrations/mastodon/index.ts
+++ b/integrations/mastodon/index.ts
@@ -1,0 +1,22 @@
+import { Integration } from "../integration.ts";
+import { createRestAPIClient, mastodon } from "npm:masto"
+import { newChangelog } from "./functionality.ts";
+
+export default class Mastodon extends Integration {
+
+    public client = createRestAPIClient({
+            url: process.env.MASTO_URL!,
+            accessToken: process.env.MASTO_TOKEN!
+        })
+
+    constructor() {
+        super();
+
+        this.start();
+    }
+
+    public async start() {
+        this.on("changelog", newChangelog)
+    }
+    
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@types/deno": "^2.3.0",
         "discord.js": "^14.19.3",
         "dotenv": "^16.5.0",
+        "masto": "^7.1.0",
         "node-html-parser": "^7.0.1"
     }
 }

--- a/src/platforms/ios.ts
+++ b/src/platforms/ios.ts
@@ -1,6 +1,6 @@
 import { Platform } from "./common.ts";
 export default class iOS extends Platform {
-    public name: string = "iOS AppStore";
+    public name: string = "iOS App Store";
     public override download: string = "https://apps.apple.com/app/apple-store/id479516143";
 
     public async fetchLatestVersion(): Promise<string> {


### PR DESCRIPTION
This pull request makes a few changes to the project:
- I added Mastodon integration along with the already existing Discord one. The environment variables used are `MASTO_URL`, the URL of the Mastodon API compliant fediverse instance, and `MASTO_TOKEN`, the access token to the application created inside of the account. You need the `read:statuses` and `write:statuses` permissions enabled for this to work
- I made the Discord and Mastodon integrations toggle-able through environment variables, with `DISCORD_INTEGRATION` and `MASTO_INTEGRATION` respectively
- Corrected a small typo for the `iOS App Store` (before: `iOS AppStore`)

Review before pushing to upstream :3